### PR TITLE
[hotfix/#24] 음악 검색 api response 수정

### DIFF
--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/SongData.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/SongData.java
@@ -20,6 +20,9 @@ public record SongData(
         @Schema(description = "커버 이미지 URL (앨범 이미지)")
         String coverImage,
 
+        @Schema(description = "노래 URL (미리듣기 등)")
+        String songUrl,
+
         @Schema(description = "iTunes URL")
         String itunesUrl,
 

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/mapper/MusicMapper.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/mapper/MusicMapper.java
@@ -33,7 +33,8 @@ public class MusicMapper {
                 .songTitle(music.getSongName())
                 .artist(music.getArtist())
                 .coverImage(music.getAlbumImageUrl())
-                .itunesUrl(music.getSongUrl())
+                .songUrl(music.getSongUrl())
+                .itunesUrl(music.getItunesUrl())
                 .build();
     }
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/util/ItunesService.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/util/ItunesService.java
@@ -71,7 +71,8 @@ public class ItunesService {
        log.info(node.toString());
         String artistName = node.path("artistName").asText();
         String trackName = node.path("trackName").asText();
-        String itunesUrl = node.path("viewUrl").asText();
+        // iTunes detail page URL is typically under 'trackViewUrl'
+        String itunesUrl = node.path("trackViewUrl").asText();
 
         return Music.builder()
                 .songName(trackName)


### PR DESCRIPTION
## 📌 작업한 내용  
검색 api에 itunesUrl과 songUrl 누락된거 수정


## 🔍 참고 사항  



## 🖼️ 스크린샷  


## 🔗 관련 이슈  
#24 

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
