### PR TITLE
[hotfix/#37] MusicChartResponse mapper에 itunesUrl 추가

### DIFF
--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/MusicChartResponse.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/MusicChartResponse.java
@@ -25,12 +25,12 @@ public class MusicChartResponse {
     @Schema(description = "앨범 이미지 URL", example = "https://example.com/album/image.jpg")
     private String coverImage;
 
-    @Schema(description = "노래 URL", example = "https://example.com/song/url")
+    @Schema(description = "노래 URL", example = "http:// a392.itunes.apple.com/jp/r10/ Music/y2005/m06/d03/h05/s05.zdzqlufu.p.m4p")
     private String songUrl;
 
     @Schema(description = "인기 점수", example = "15.5")
     private double score;
 
-    @Schema(description = "iTunes URL", example = "http:// a392.itunes.apple.com/jp/r10/ Music/y2005/m06/d03/h05/s05.zdzqlufu.p.m4p")
+    @Schema(description = "iTunes URL", example = "https://music.apple.com/kr/album/%EA%B7%B8%EB%A6%AC%EC%9B%8C%ED%95%98%EB%8B%A4/1296748148?i=1296748271&uo=4")
     private String iTunesUrl;
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/MusicChartResponse.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/MusicChartResponse.java
@@ -32,5 +32,5 @@ public class MusicChartResponse {
     private double score;
 
     @Schema(description = "iTunes URL", example = "https://music.apple.com/kr/album/%EA%B7%B8%EB%A6%AC%EC%9B%8C%ED%95%98%EB%8B%A4/1296748148?i=1296748271&uo=4")
-    private String iTunesUrl;
+    private String itunesUrl;
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/mapper/MusicMapper.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/mapper/MusicMapper.java
@@ -25,6 +25,7 @@ public class MusicMapper {
                 .coverImage(music.getAlbumImageUrl())
                 .songUrl(music.getSongUrl())
                 .score(score)
+                .itunesUrl(music.getItunesUrl())
                 .build();
     }
 


### PR DESCRIPTION
## 📌 작업한 내용  
MusicChartResponse mapper에 itunesUrl 추가

## 🔍 참고 사항  


## 🖼️ 스크린샷  


## 🔗 관련 이슈  
#37

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
