### PR TITLE
[hotfix/#45] 프로필 업데이트 api 수정

### DIFF
--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/request/UpdateBoardRequest.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/request/UpdateBoardRequest.java
@@ -13,5 +13,5 @@ import org.springframework.web.multipart.MultipartFile;
 public class UpdateBoardRequest {
 
     private String nickname;
-    private MultipartFile profileImage;
+    private String profileImage;
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCaseImpl.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCaseImpl.java
@@ -131,54 +131,39 @@ public class BoardUseCaseImpl implements BoardUseCase {
         Board board = boardRepository.findByUser(user)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
 
-        String currentNickname = board.getNickname();
-        String currentProfileImage = user.getProfileImage();
-        String newProfileImageUrl = currentProfileImage;
-        String newNickname = currentNickname;
-        User finalUser = user;
-        log.info("nickname from request: {}", request.getNickname());
-        
-        // 2. 사용자 프로필 이미지 반영 (이미지 요청이 있는 경우에만 실행)
-        if (request.getProfileImage() != null) { 
-            // A. 기존 이미지 삭제
-            if (user.getProfileImage() != null) {
+        // 2. 프로필 이미지 업데이트 (Base64 이미지가 있는 경우에만)
+        if (request.getProfileImage() != null && !request.getProfileImage().trim().isEmpty()) {
+            // 기존 이미지 삭제
+            if (user.getProfileImage() != null && !user.getProfileImage().isEmpty()) {
                 try {
                     s3UploadService.deleteImage(user.getProfileImage());
-
                 } catch (CustomException e) {
                     log.warn("기존 프로필 이미지 S3 삭제 실패: {}", user.getProfileImage(), e);
                 }
             }
-            newProfileImageUrl = s3UploadService.uploadImage(request.getProfileImage());
-            // B. 새 이미지 S3에 업로드 및 C. User 엔티티에 새 URL 저장
+            
+            // 새 이미지 업로드 및 User 엔티티 업데이트
+            String newProfileImageUrl = s3UploadService.uploadImage(request.getProfileImage());
+            user.update(null, null, newProfileImageUrl);
+            user = userRepository.saveAndFlush(user);
         }
-        user.update(null, null, newProfileImageUrl);
-        finalUser = userRepository.saveAndFlush(user); // User 엔티티 변경사항 DB 반영 및 finalUser 갱신
 
-        // 3. 닉네임 업데이트 (닉네임 요청이 있는 경우에만 실행)
+        // 3. 닉네임 업데이트 (닉네임이 있는 경우에만)
         if (request.getNickname() != null && !request.getNickname().isBlank()) {
-            newNickname = request.getNickname();
+            boardRepository.updateNicknameByUser(user, request.getNickname());
         }
-        board.updateNickname(newNickname);
-        
-        // ⭐ 변경 1: flush를 통해 DB에 변경사항을 강제 반영합니다.
-        boardRepository.save(board); 
-        boardRepository.flush();
-        
-        // ⭐ 변경 2: EntityManager.refresh()를 사용하여 DB의 최신값을 메모리 객체로 강제 로드합니다.
-        // board 객체의 닉네임이 최신 값으로 갱신됩니다.
-        entityManager.refresh(board); 
-        log.info("After flush & refresh - Board nickname: {}, User profileImage: {}", board.getNickname(), user.getProfileImage());
-        // 4. 응답 생성
-        // 닉네임은 board 엔티티에서 최신 값이 반영된 상태입니다.
-        // 프로필 이미지는 finalUser 엔티티에서 최신 값이 반영된 상태입니다.
 
+        // 4. 최신 보드 재조회
+        Board savedBoard = boardRepository.findByUser(user)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
+
+        // 5. 응답 생성
         return UpdateBoardResponse.builder()
-                .boardId(board.getBoardId())
-                .userId(finalUser.getUserId())
-                .nickname(board.getNickname())
-                .profileImage(finalUser.getProfileImage())
-                .shareUri(board.getShareUri())
+                .boardId(savedBoard.getBoardId())
+                .userId(user.getUserId())
+                .nickname(savedBoard.getNickname())
+                .profileImage(user.getProfileImage())
+                .shareUri(savedBoard.getShareUri())
                 .build();
     }
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/service/S3UploadService.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/service/S3UploadService.java
@@ -3,24 +3,22 @@ package com.goormthon.backend.firstsori.domain.board.domain.service;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.util.IOUtils;
 import com.goormthon.backend.firstsori.global.common.exception.ErrorCode;
 import com.goormthon.backend.firstsori.global.common.response.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.util.Arrays;
+import java.util.Base64;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Component
 @RequiredArgsConstructor
@@ -32,116 +30,125 @@ public class S3UploadService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    private String saveImage(MultipartFile image) {
-        String fileName = image.getOriginalFilename();
-
-        String fileExtension = validateImageFileExtension(fileName);
-
-        try {
-            return
-
-
-                    saveImageToS3(image, fileName, fileExtension);
-        } catch (IOException e) {
-            throw new CustomException(ErrorCode.IO_EXCEPTION_ON_IMAGE_SAVE);
+    /**
+     * Base64 문자열에서 이미지 타입 추출
+     * data:image/png;base64,iVBORw0KG... 형식에서 png 추출
+     */
+    private String extractImageTypeFromBase64(String base64Image) {
+        if (base64Image.startsWith("data:image/")) {
+            Pattern pattern = Pattern.compile("data:image/([a-zA-Z]+);base64,");
+            Matcher matcher = pattern.matcher(base64Image);
+            if (matcher.find()) {
+                return matcher.group(1).toLowerCase();
+            }
         }
-
+        // 기본값으로 png 반환
+        return "png";
     }
 
     /**
-     * 파일 확장자 확인 하기 (확장자가 jpg, jpeg, png, gif 가 아니면 예외 처리)
+     * Base64 문자열에서 실제 데이터 부분만 추출
      */
-    private String validateImageFileExtension(String fileName) {
-
-        int lastDot = fileName.lastIndexOf(".");
-
-        if (lastDot == -1) {
-            throw new CustomException(ErrorCode.NO_FILE_EXTENSION);
+    private String extractBase64Data(String base64Image) {
+        if (base64Image.contains(",")) {
+            return base64Image.split(",")[1];
         }
+        return base64Image;
+    }
 
+    /**
+     * 파일 확장자 유효성 검증
+     */
+    private void validateImageFileExtension(String fileExtension) {
         String[] allowedExtensions = {"jpg", "jpeg", "png", "gif"};
-        String fileExtension = fileName
-                .substring(lastDot + 1)
-                .toLowerCase();
-
-        if (!Arrays.asList(allowedExtensions).contains(fileExtension)) {
+        boolean isValid = false;
+        
+        for (String ext : allowedExtensions) {
+            if (ext.equalsIgnoreCase(fileExtension)) {
+                isValid = true;
+                break;
+            }
+        }
+        
+        if (!isValid) {
             throw new CustomException(ErrorCode.INVALID_FILE_EXTENSION);
         }
-
-        return fileExtension;
-
-
     }
 
     /**
-     * S3에 이미지 파일 저장하기
+     * Base64 문자열을 디코딩하여 S3에 저장
      */
-    private String saveImageToS3(MultipartFile image,
-                                 String originalFilename,
-                                 String fileExtension) throws IOException {
-
-        // S3에 저장할 파일 이름을 UUID로 생성 (중복 방지)
-        String newS3FileName = UUID.randomUUID().toString().substring(0, 10)
-                + "_" + originalFilename;
-
-        InputStream inputStream = image.getInputStream();
-        byte[] bytes = IOUtils.toByteArray(inputStream);
-
-        // Amazon S3에 저장되는 파일 또는 객체와 관련된 정보 (파일의 유형, 크기, 버전 등)
-        // 사용자가 정의한 추가적인 정보를 포함할 수 있음. 파일의 작성자, 설명, 태그
-        ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentType("image/" + fileExtension);
-        metadata.setContentLength(bytes.length);
-
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
-
+    private String saveBase64ImageToS3(String base64Image, String fileExtension) {
         try {
-            // PutObjectRequest : Amazon S3에 객체를 저장하는 요청
+            // Base64 데이터 추출 및 디코딩
+            String base64Data = extractBase64Data(base64Image);
+            byte[] imageBytes = Base64.getDecoder().decode(base64Data);
+
+            // S3에 저장할 파일 이름 생성 (UUID 사용)
+            String newS3FileName = UUID.randomUUID().toString().substring(0, 10)
+                    + "_image." + fileExtension;
+
+            // 메타데이터 설정
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType("image/" + fileExtension);
+            metadata.setContentLength(imageBytes.length);
+
+            // S3에 업로드
+            ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(imageBytes);
             PutObjectRequest putObjectRequest =
                     new PutObjectRequest(bucket, newS3FileName, byteArrayInputStream, metadata);
 
             amazonS3.putObject(putObjectRequest);
 
+            return amazonS3.getUrl(bucket, newS3FileName).toString();
+
+        } catch (IllegalArgumentException e) {
+            log.error("Base64 디코딩 실패", e);
+            throw new CustomException(ErrorCode.INVALID_FILE_EXTENSION);
         } catch (Exception e) {
+            log.error("S3 업로드 실패", e);
             throw new CustomException(ErrorCode.PUT_OBJECT_ERROR);
         }
-
-        return amazonS3.getUrl(bucket, newS3FileName).toString();
     }
 
     /**
      * 이미지 파일의 주소로부터 key 추출
      */
     private String getKeyFromImageAddress(String imageAddress) {
-
         try {
             URL url = new URL(imageAddress);
             String key = URLDecoder.decode(url.getPath(), "UTF-8");
-
             return key.substring(1);
-
         } catch (MalformedURLException | UnsupportedEncodingException e) {
             throw new CustomException(ErrorCode.INVALID_FILE_EXTENSION);
         }
     }
 
     /**
-     * 이미지 파일을 S3에 저장 먼저 이미지 파일이 비어있는지 확인 (비어있으면 예외 처리)
+     * Base64 인코딩된 이미지 문자열을 받아서 S3에 저장
+     * 
+     * @param base64Image Base64 인코딩된 이미지 문자열 
+     *                    (예: "data:image/png;base64,iVBORw0KG..." 또는 순수 Base64 문자열)
+     * @return S3에 저장된 이미지의 URL
      */
-    public String uploadImage(MultipartFile image) {
-        if (image == null || image.isEmpty() || image.getOriginalFilename() == null) {
+    public String uploadImage(String base64Image) {
+        // 빈 문자열 체크
+        if (base64Image == null || base64Image.trim().isEmpty()) {
             throw new CustomException(ErrorCode.EMPTY_FILE);
         }
 
-        return saveImage(image);
-    }
+        // 이미지 타입 추출 및 검증
+        String fileExtension = extractImageTypeFromBase64(base64Image);
+        validateImageFileExtension(fileExtension);
 
+        // S3에 저장
+        return saveBase64ImageToS3(base64Image, fileExtension);
+    }
 
     /**
      * 이미지의 Key를 가지고 와서 S3내 객체를 삭제한다
      */
     public void deleteImage(String urlAddress) {
-
         String key = getKeyFromImageAddress(urlAddress);
 
         try {
@@ -149,6 +156,5 @@ public class S3UploadService {
         } catch (Exception e) {
             throw new CustomException(ErrorCode.IO_EXCEPTION_ON_IMAGE_DELETE);
         }
-
     }
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/BoardController.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/BoardController.java
@@ -95,7 +95,7 @@ public class BoardController implements BoardControllerSpec {
     // 보드 수정 (닉네임, 프로필 이미지)
     @PatchMapping("/update")
     public ApiResponse<UpdateBoardResponse> updateBoard(
-            @ModelAttribute UpdateBoardRequest request,
+            @RequestBody UpdateBoardRequest request,
             @AuthenticationPrincipal PrincipalDetails user
     ) {
         UpdateBoardResponse response = boardUseCase.updateBoard(request, user.getUser());


### PR DESCRIPTION
## 📌 작업한 내용  
- updateboard response의 profileImage 타입 string으로 변환
- base64 이미지를 디코딩하여 s3 업로드하도록 서비스 수정
- api의 request를 requestbody로 수정
- api의 필요 없는 변수, 로직 삭제


## 🔍 참고 사항  



## 🖼️ 스크린샷  


## 🔗 관련 이슈  
#45
## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
